### PR TITLE
Enable module pages and dynamic landing navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,7 @@
+title: Forty
+author: Diogo Neno
+subtitle: by HTML5 UP
+markdown: kramdown
+exclude:
+  - README.txt
+  - LICENSE.txt

--- a/_includes/nav-links.html
+++ b/_includes/nav-links.html
@@ -1,0 +1,18 @@
+<li{% if page.url == '/' %} class="active"{% endif %}>
+  <a href="{{ '/' | relative_url }}">Home</a>
+</li>
+<li{% if page.url == '/landing.html' %} class="active"{% endif %}>
+  <a href="{{ '/landing.html' | relative_url }}">Landing</a>
+</li>
+<li{% if page.url == '/generic.html' %} class="active"{% endif %}>
+  <a href="{{ '/generic.html' | relative_url }}">Generic</a>
+</li>
+<li{% if page.url == '/elements.html' %} class="active"{% endif %}>
+  <a href="{{ '/elements.html' | relative_url }}">Elements</a>
+</li>
+{% assign module_pages = site.pages | where_exp: 'item', 'item["nav-menu"]' | sort: 'title' %}
+{% for module in module_pages %}
+<li{% if module.url == page.url %} class="active"{% endif %}>
+  <a href="{{ module.url | relative_url }}">{{ module.title }}</a>
+</li>
+{% endfor %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,136 @@
+<!DOCTYPE HTML>
+<!--
+        Forty by HTML5 UP
+        html5up.net | @ajlkn
+        Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+-->
+<html>
+  <head>
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title | default: 'Forty by HTML5 UP' }}</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+    {% assign meta_description = page.summary | default: page.description %}
+    {% if meta_description %}
+    <meta name="description" content="{{ meta_description | strip_html | strip_newlines | replace: '  ', ' ' | truncate: 160 }}" />
+    {% endif %}
+    <link rel="stylesheet" href="{{ 'assets/css/main.css' | relative_url }}" />
+    <noscript><link rel="stylesheet" href="{{ 'assets/css/noscript.css' | relative_url }}" /></noscript>
+  </head>
+  <body class="is-preload">
+    <!-- Wrapper -->
+    <div id="wrapper">
+      <!-- Header -->
+      <header id="header">
+        <a href="{{ '/' | relative_url }}" class="logo"><strong>{{ site.title | default: 'Forty' }}</strong> <span>{{ site.subtitle | default: 'by HTML5 UP' }}</span></a>
+        <nav>
+          <a href="#menu">Menu</a>
+        </nav>
+      </header>
+
+      <!-- Menu -->
+      <nav id="menu">
+        <ul class="links">
+          {% include nav-links.html %}
+        </ul>
+        <ul class="actions stacked">
+          <li><a href="#" class="button primary fit">Get Started</a></li>
+          <li><a href="#" class="button fit">Log In</a></li>
+        </ul>
+      </nav>
+
+      <!-- Main -->
+      <div id="main" class="alt">
+        <section id="one">
+          <div class="inner">
+            <header class="major">
+              <h1>{{ page.title }}</h1>
+              {% if page.description %}
+              <p>{{ page.description }}</p>
+              {% endif %}
+            </header>
+            {{ content }}
+          </div>
+        </section>
+      </div>
+
+      <!-- Contact -->
+      <section id="contact">
+        <div class="inner">
+          <section>
+            <form method="post" action="#">
+              <div class="fields">
+                <div class="field half">
+                  <label for="name">Name</label>
+                  <input type="text" name="name" id="name" />
+                </div>
+                <div class="field half">
+                  <label for="email">Email</label>
+                  <input type="text" name="email" id="email" />
+                </div>
+                <div class="field">
+                  <label for="message">Message</label>
+                  <textarea name="message" id="message" rows="6"></textarea>
+                </div>
+              </div>
+              <ul class="actions">
+                <li><input type="submit" value="Send Message" class="primary" /></li>
+                <li><input type="reset" value="Clear" /></li>
+              </ul>
+            </form>
+          </section>
+          <section class="split">
+            <section>
+              <div class="contact-method">
+                <span class="icon solid alt fa-envelope"></span>
+                <h3>Email</h3>
+                <a href="#">information@untitled.tld</a>
+              </div>
+            </section>
+            <section>
+              <div class="contact-method">
+                <span class="icon solid alt fa-phone"></span>
+                <h3>Phone</h3>
+                <span>(000) 000-0000 x12387</span>
+              </div>
+            </section>
+            <section>
+              <div class="contact-method">
+                <span class="icon solid alt fa-home"></span>
+                <h3>Address</h3>
+                <span>1234 Somewhere Road #5432<br />
+                Nashville, TN 00000<br />
+                United States of America</span>
+              </div>
+            </section>
+          </section>
+        </div>
+      </section>
+
+      <!-- Footer -->
+      <footer id="footer">
+        <div class="inner">
+          <ul class="icons">
+            <li><a href="#" class="icon brands alt fa-twitter"><span class="label">Twitter</span></a></li>
+            <li><a href="#" class="icon brands alt fa-facebook-f"><span class="label">Facebook</span></a></li>
+            <li><a href="#" class="icon brands alt fa-instagram"><span class="label">Instagram</span></a></li>
+            <li><a href="#" class="icon brands alt fa-github"><span class="label">GitHub</span></a></li>
+            <li><a href="#" class="icon brands alt fa-linkedin-in"><span class="label">LinkedIn</span></a></li>
+          </ul>
+          <ul class="copyright">
+            <li>&copy; {{ site.time | date: '%Y' }} {{ site.title | default: 'Untitled' }}</li>
+            <li>Design: <a href="https://html5up.net">HTML5 UP</a></li>
+          </ul>
+        </div>
+      </footer>
+    </div>
+
+    <!-- Scripts -->
+    <script src="{{ 'assets/js/jquery.min.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/jquery.scrolly.min.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/jquery.scrollex.min.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/browser.min.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/breakpoints.min.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/util.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/main.js' | relative_url }}"></script>
+  </body>
+</html>

--- a/elements.html
+++ b/elements.html
@@ -1,3 +1,6 @@
+---
+layout: null
+---
 <!DOCTYPE HTML>
 <!--
 	Forty by HTML5 UP
@@ -18,21 +21,18 @@
 			<div id="wrapper">
 
 				<!-- Header -->
-					<header id="header">
-						<a href="index.html" class="logo"><strong>Forty</strong> <span>by HTML5 UP</span></a>
+                                        <header id="header">
+                                                <a href="{{ '/' | relative_url }}" class="logo"><strong>{{ site.title }}</strong> <span>{{ site.subtitle }}</span></a>
 						<nav>
 							<a href="#menu">Menu</a>
 						</nav>
 					</header>
 
 				<!-- Menu -->
-					<nav id="menu">
-						<ul class="links">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="landing.html">Landing</a></li>
-							<li><a href="generic.html">Generic</a></li>
-							<li><a href="elements.html">Elements</a></li>
-						</ul>
+                                        <nav id="menu">
+                                                <ul class="links">
+                                                        {% include nav-links.html %}
+                                                </ul>
 						<ul class="actions stacked">
 							<li><a href="#" class="button primary fit">Get Started</a></li>
 							<li><a href="#" class="button fit">Log In</a></li>

--- a/generic.html
+++ b/generic.html
@@ -1,3 +1,6 @@
+---
+layout: null
+---
 <!DOCTYPE HTML>
 <!--
 	Forty by HTML5 UP
@@ -18,21 +21,18 @@
 			<div id="wrapper">
 
 				<!-- Header -->
-					<header id="header">
-						<a href="index.html" class="logo"><strong>Forty</strong> <span>by HTML5 UP</span></a>
+                                        <header id="header">
+                                                <a href="{{ '/' | relative_url }}" class="logo"><strong>{{ site.title }}</strong> <span>{{ site.subtitle }}</span></a>
 						<nav>
 							<a href="#menu">Menu</a>
 						</nav>
 					</header>
 
 				<!-- Menu -->
-					<nav id="menu">
-						<ul class="links">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="landing.html">Landing</a></li>
-							<li><a href="generic.html">Generic</a></li>
-							<li><a href="elements.html">Elements</a></li>
-						</ul>
+                                        <nav id="menu">
+                                                <ul class="links">
+                                                        {% include nav-links.html %}
+                                                </ul>
 						<ul class="actions stacked">
 							<li><a href="#" class="button primary fit">Get Started</a></li>
 							<li><a href="#" class="button fit">Log In</a></li>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,6 @@
+---
+layout: null
+---
 <!DOCTYPE HTML>
 <!--
 	Forty by HTML5 UP
@@ -18,21 +21,18 @@
 			<div id="wrapper">
 
 				<!-- Header -->
-					<header id="header" class="alt">
-						<a href="index.html" class="logo"><strong>Forty</strong> <span>by HTML5 UP</span></a>
+                                        <header id="header" class="alt">
+                                                <a href="{{ '/' | relative_url }}" class="logo"><strong>{{ site.title }}</strong> <span>{{ site.subtitle }}</span></a>
 						<nav>
 							<a href="#menu">Menu</a>
 						</nav>
 					</header>
 
 				<!-- Menu -->
-					<nav id="menu">
-						<ul class="links">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="landing.html">Landing</a></li>
-							<li><a href="generic.html">Generic</a></li>
-							<li><a href="elements.html">Elements</a></li>
-						</ul>
+                                        <nav id="menu">
+                                                <ul class="links">
+                                                        {% include nav-links.html %}
+                                                </ul>
 						<ul class="actions stacked">
 							<li><a href="#" class="button primary fit">Get Started</a></li>
 							<li><a href="#" class="button fit">Log In</a></li>

--- a/landing.html
+++ b/landing.html
@@ -1,3 +1,6 @@
+---
+layout: null
+---
 <!DOCTYPE HTML>
 <!--
 	Forty by HTML5 UP
@@ -19,21 +22,18 @@
 
 				<!-- Header -->
 				<!-- Note: The "styleN" class below should match that of the banner element. -->
-					<header id="header" class="alt style2">
-						<a href="index.html" class="logo"><strong>Forty</strong> <span>by HTML5 UP</span></a>
+                                        <header id="header" class="alt style2">
+                                                <a href="{{ '/' | relative_url }}" class="logo"><strong>{{ site.title }}</strong> <span>{{ site.subtitle }}</span></a>
 						<nav>
 							<a href="#menu">Menu</a>
 						</nav>
 					</header>
 
 				<!-- Menu -->
-					<nav id="menu">
-						<ul class="links">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="landing.html">Landing</a></li>
-							<li><a href="generic.html">Generic</a></li>
-							<li><a href="elements.html">Elements</a></li>
-						</ul>
+                                        <nav id="menu">
+                                                <ul class="links">
+                                                        {% include nav-links.html %}
+                                                </ul>
 						<ul class="actions stacked">
 							<li><a href="#" class="button primary fit">Get Started</a></li>
 							<li><a href="#" class="button fit">Log In</a></li>
@@ -58,7 +58,8 @@
 					</section>
 
 				<!-- Main -->
-					<div id="main">
+                                        <div id="main">
+                                                {% assign module_pages = site.pages | where_exp: 'item', 'item["nav-menu"]' | sort: 'title' %}
 
 						<!-- One -->
 							<section id="one">
@@ -70,57 +71,48 @@
 								</div>
 							</section>
 
-						<!-- Two -->
-							<section id="two" class="spotlights">
-								<section>
-									<a href="generic.html" class="image">
-										<img src="images/pic08.jpg" alt="" data-position="center center" />
-									</a>
-									<div class="content">
-										<div class="inner">
-											<header class="major">
-												<h3>Orci maecenas</h3>
-											</header>
-											<p>Nullam et orci eu lorem consequat tincidunt vivamus et sagittis magna sed nunc rhoncus condimentum sem. In efficitur ligula tate urna. Maecenas massa sed magna lacinia magna pellentesque lorem ipsum dolor. Nullam et orci eu lorem consequat tincidunt. Vivamus et sagittis tempus.</p>
-											<ul class="actions">
-												<li><a href="generic.html" class="button">Learn more</a></li>
-											</ul>
-										</div>
-									</div>
-								</section>
-								<section>
-									<a href="generic.html" class="image">
-										<img src="images/pic09.jpg" alt="" data-position="top center" />
-									</a>
-									<div class="content">
-										<div class="inner">
-											<header class="major">
-												<h3>Rhoncus magna</h3>
-											</header>
-											<p>Nullam et orci eu lorem consequat tincidunt vivamus et sagittis magna sed nunc rhoncus condimentum sem. In efficitur ligula tate urna. Maecenas massa sed magna lacinia magna pellentesque lorem ipsum dolor. Nullam et orci eu lorem consequat tincidunt. Vivamus et sagittis tempus.</p>
-											<ul class="actions">
-												<li><a href="generic.html" class="button">Learn more</a></li>
-											</ul>
-										</div>
-									</div>
-								</section>
-								<section>
-									<a href="generic.html" class="image">
-										<img src="images/pic10.jpg" alt="" data-position="25% 25%" />
-									</a>
-									<div class="content">
-										<div class="inner">
-											<header class="major">
-												<h3>Sed nunc ligula</h3>
-											</header>
-											<p>Nullam et orci eu lorem consequat tincidunt vivamus et sagittis magna sed nunc rhoncus condimentum sem. In efficitur ligula tate urna. Maecenas massa sed magna lacinia magna pellentesque lorem ipsum dolor. Nullam et orci eu lorem consequat tincidunt. Vivamus et sagittis tempus.</p>
-											<ul class="actions">
-												<li><a href="generic.html" class="button">Learn more</a></li>
-											</ul>
-										</div>
-									</div>
-								</section>
-							</section>
+                                                <!-- Two -->
+                                                        <section id="two" class="spotlights">
+{% if module_pages.size > 0 %}
+{% for module in module_pages %}
+{% capture module_image %}{% cycle 'module_image': 'images/pic08.jpg', 'images/pic09.jpg', 'images/pic10.jpg', 'images/pic11.jpg' %}{% endcapture %}
+                                                                <section>
+                                                                        <a href="{{ module.url | relative_url }}" class="image">
+                                                                                <img src="{{ module_image | strip | relative_url }}" alt="" data-position="center center" />
+                                                                        </a>
+                                                                        <div class="content">
+                                                                                <div class="inner">
+                                                                                        <header class="major">
+                                                                                                <h3>{{ module.title }}</h3>
+                                                                                        </header>
+{% if module.description %}
+                                                                                        <p><strong>{{ module.description }}</strong></p>
+{% endif %}
+{% if module.summary %}
+                                                                                        <p>{{ module.summary }}</p>
+{% else %}
+                                                                                        <p>{{ module.excerpt | strip_html | strip_newlines | truncate: 220 }}</p>
+{% endif %}
+                                                                                        <ul class="actions">
+                                                                                                <li><a href="{{ module.url | relative_url }}" class="button">Learn more</a></li>
+                                                                                        </ul>
+                                                                                </div>
+                                                                        </div>
+                                                                </section>
+{% endfor %}
+{% else %}
+                                                                <section>
+                                                                        <div class="content">
+                                                                                <div class="inner">
+                                                                                        <header class="major">
+                                                                                                <h3>No modules published yet</h3>
+                                                                                        </header>
+                                                                                        <p>Add Markdown files with <code>layout: page</code> and <code>nav-menu: true</code> to populate this section.</p>
+                                                                                </div>
+                                                                        </div>
+                                                                </section>
+{% endif %}
+                                                        </section>
 
 						<!-- Three -->
 							<section id="three">
@@ -129,9 +121,11 @@
 										<h2>Massa libero</h2>
 									</header>
 									<p>Nullam et orci eu lorem consequat tincidunt vivamus et sagittis libero. Mauris aliquet magna magna sed nunc rhoncus pharetra. Pellentesque condimentum sem. In efficitur ligula tate urna. Maecenas laoreet massa vel lacinia pellentesque lorem ipsum dolor. Nullam et orci eu lorem consequat tincidunt. Vivamus et sagittis libero. Mauris aliquet magna magna sed nunc rhoncus amet pharetra et feugiat tempus.</p>
-									<ul class="actions">
-										<li><a href="generic.html" class="button next">Get Started</a></li>
-									</ul>
+{% if module_pages.size > 0 %}
+                                                                        <ul class="actions">
+                                                                                <li><a href="{{ module_pages.first.url | relative_url }}" class="button next">Get Started</a></li>
+                                                                        </ul>
+{% endif %}
 								</div>
 							</section>
 

--- a/secure-software-development.md
+++ b/secure-software-development.md
@@ -3,6 +3,9 @@ layout: page
 title: Secure Software Development
 description: January 2025
 nav-menu: true
+summary: >-
+  Integrated SSDF and OWASP SAMM practices across the agile SDLC, combining UML
+  modelling, secure coding guidance, and automated testing to reduce risk early.
 ---
 
 <section aria-labelledby="ssd-title" class="prose max-w-none">

--- a/security-and-risk-management.md
+++ b/security-and-risk-management.md
@@ -3,6 +3,10 @@ layout: page
 title: Security and Risk Management
 description: October 2024
 nav-menu: true
+summary: >-
+  Investigated security governance and quantitative risk assessment, aligning
+  NIST, ISO 27001, and STRIDE practices with legal, ethical, and communication
+  requirements for stakeholders.
 ---
 
 <section id="introduction">


### PR DESCRIPTION
## Summary
- add site configuration, shared layout, and navigation include so Markdown module pages render with the Forty theme
- update static pages to pull in the shared navigation and site title values
- list published modules dynamically on the landing page with summaries and links

## Testing
- not run (jekyll build not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68f8cc3a5e4c8327ac63d3d170f1c95b