### PR TITLE
Add contact details to landing page

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -177,7 +177,39 @@ layout: null
     </div>
     </section>
 
-				</div>
+    <!-- Contact -->
+    <section id="contact">
+    <div class="inner">
+    <header class="major">
+    <h2>Contact</h2>
+    </header>
+    <section class="split">
+    <section>
+    <div class="contact-method">
+    <span class="icon solid alt fa-envelope"></span>
+    <h3>Email</h3>
+    <a href="mailto:diogoneno@proton.me">diogoneno@proton.me</a>
+    </div>
+    </section>
+    <section>
+    <div class="contact-method">
+    <span class="icon brands alt fa-linkedin"></span>
+    <h3>LinkedIn</h3>
+    <a href="https://www.linkedin.com/in/diogoamarantes/" target="_blank" rel="noopener">https://www.linkedin.com/in/diogoamarantes/</a>
+    </div>
+    </section>
+    <section>
+    <div class="contact-method">
+    <span class="icon brands alt fa-github"></span>
+    <h3>GitHub</h3>
+    <a href="https://github.com/diogoneno" target="_blank" rel="noopener">https://github.com/diogoneno</a>
+    </div>
+    </section>
+    </section>
+    </div>
+    </section>
+
+                                </div>
 
     <!-- Footer -->
     <footer id="footer">


### PR DESCRIPTION
## Summary
- add a contact section to the landing page with direct links to email, LinkedIn, and GitHub

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_6904af71b1688325a598d3bb4ae13207