### PR TITLE
Configure contact links for portfolio pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,8 @@ markdown: kramdown
 exclude:
   - README.txt
   - LICENSE.txt
+
+# Contact details
+email: diogoneno@proton.me
+linkedin_url: https://www.linkedin.com/in/diogoamarantes/
+github_url: https://github.com/diogoneno

--- a/index.html
+++ b/index.html
@@ -655,11 +655,11 @@ layout: null
             </div>
             <div class="contact-card">
                 <h3>LinkedIn</h3>
-                <p><a href="{{ site.linkedin | default: '#' }}" target="_blank" rel="noopener">{{ site.linkedin | default: 'linkedin.com/in/yourprofile' }}</a></p>
+                <p><a href="{{ site.linkedin_url | default: '#' }}" target="_blank" rel="noopener">{{ site.linkedin_url | default: 'https://www.linkedin.com/in/yourprofile/' }}</a></p>
             </div>
             <div class="contact-card">
                 <h3>GitHub</h3>
-                <p><a href="{{ site.github | default: '#' }}" target="_blank" rel="noopener">{{ site.github | default: 'github.com/yourusername' }}</a></p>
+                <p><a href="{{ site.github_url | default: '#' }}" target="_blank" rel="noopener">{{ site.github_url | default: 'https://github.com/yourusername' }}</a></p>
             </div>
         </div>
     </section>

--- a/landing.html
+++ b/landing.html
@@ -177,7 +177,39 @@ layout: null
     </div>
     </section>
 
-				</div>
+    <!-- Contact -->
+    <section id="contact">
+    <div class="inner">
+    <header class="major">
+    <h2>Contact</h2>
+    </header>
+    <section class="split">
+    <section>
+    <div class="contact-method">
+    <span class="icon solid alt fa-envelope"></span>
+    <h3>Email</h3>
+    <a href="mailto:{{ site.email | default: 'hello@example.com' }}">{{ site.email | default: 'hello@example.com' }}</a>
+    </div>
+    </section>
+    <section>
+    <div class="contact-method">
+    <span class="icon brands alt fa-linkedin"></span>
+    <h3>LinkedIn</h3>
+    <a href="{{ site.linkedin_url | default: '#' }}" target="_blank" rel="noopener">{{ site.linkedin_url | default: 'https://www.linkedin.com/in/yourprofile/' }}</a>
+    </div>
+    </section>
+    <section>
+    <div class="contact-method">
+    <span class="icon brands alt fa-github"></span>
+    <h3>GitHub</h3>
+    <a href="{{ site.github_url | default: '#' }}" target="_blank" rel="noopener">{{ site.github_url | default: 'https://github.com/yourusername' }}</a>
+    </div>
+    </section>
+    </section>
+    </div>
+    </section>
+
+                                </div>
 
     <!-- Footer -->
     <footer id="footer">


### PR DESCRIPTION
## Summary
- add email, LinkedIn, and GitHub contact metadata to the site configuration
- update the landing and home page contact sections to use the shared metadata for consistent rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_6904af71b1688325a598d3bb4ae13207