### PR TITLE
Add module-specific tags for landing page cards

### DIFF
--- a/about-me.md
+++ b/about-me.md
@@ -7,6 +7,9 @@ nav-order: 1
 summary: >-
   Overview of my journey into cyber security, professional focus areas, and the
   values that guide my work with teams and organisations.
+topic_tags:
+  - Professional Profile
+  - Career Journey
 ---
 
 <section aria-labelledby="about-overview" class="prose max-w-none">

--- a/launching-into-cyber-security.md
+++ b/launching-into-cyber-security.md
@@ -7,6 +7,9 @@ nav-order: 2
 summary: >-
   Foundation module covering cyber security principles, secure system design, and professional
   standards with practical implementation through portfolio artefacts.
+topic_tags:
+  - Security Foundations
+  - Systems Thinking
 ---
 
 <!-- Module Overview Hero -->

--- a/network-security.md
+++ b/network-security.md
@@ -7,6 +7,9 @@ nav-order: 3
 summary: >-
   Highlights from audits and executive reporting that strengthened networked backup,
   failover, and encryption across enterprise environments.
+topic_tags:
+  - Network Defence
+  - Threat Response
 ---
 
 <!-- Module Overview Hero -->

--- a/research-methods-and-professional-practice.md
+++ b/research-methods-and-professional-practice.md
@@ -7,6 +7,9 @@ nav-order: 8
 summary: >-
   Documented the methodologies, literature reviews, and reflective practice used
   to plan and execute cyber security research.
+topic_tags:
+  - Academic Research
+  - Professional Practice
 ---
 
 <section aria-labelledby="research-overview" class="prose max-w-none">

--- a/secure-software-development.md
+++ b/secure-software-development.md
@@ -8,6 +8,9 @@ summary: >-
   Architecture-led approach to secure software development, UML-driven design,
   and assurance activities that embed security as a first-class requirement
   across the SDLC.
+topic_tags:
+  - Application Security
+  - DevSecOps
 ---
 
 <!-- Module Overview Hero -->

--- a/secure-systems-architecture.md
+++ b/secure-systems-architecture.md
@@ -7,6 +7,9 @@ nav-order: 7
 summary: >-
   Architecture-led approach to threat modelling, control selection, and
   verification across complex systems.
+topic_tags:
+  - Systems Design
+  - Zero Trust
 ---
 
 <html lang="en-GB">

--- a/security-and-risk-management.md
+++ b/security-and-risk-management.md
@@ -8,6 +8,9 @@ summary: >-
   Identified, modelled, and quantified risk across socio-technical systems, then
   translated insight into prescriptive controls, continuity strategies, and
   executive-ready communication.
+topic_tags:
+  - Risk Governance
+  - Compliance Strategy
 ---
 
 <!-- Module Overview Hero -->

--- a/the-human-factor.md
+++ b/the-human-factor.md
@@ -8,6 +8,9 @@ nav-order: 6
 summary: >-
   Behavioural and cultural interventions that embed privacy, accessibility,
   and ethics into security programmes by design.
+topic_tags:
+  - Security Awareness
+  - Human-Centred Design
 ---
 
 <!-- Module Overview Hero -->


### PR DESCRIPTION
## Summary
- add module-specific topic_tags front matter to each portfolio page
- allow landing page module cards to display tailored labels instead of the generic fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6904b4f28a3083258e2688d73fc43c02